### PR TITLE
EWN-12340 Fix error fields parsing caused by missing default "string" type

### DIFF
--- a/src/ApiDocField.test.ts
+++ b/src/ApiDocField.test.ts
@@ -79,4 +79,12 @@ describe("apiDoc Field", () => {
 
         expect(arrayField.type).toBe("string");
     });
+
+    it("should consider missing type as string", () => {
+        const missingTypeField = new ApiDocField({
+            field: "fieldName",
+        });
+
+        expect(missingTypeField.type).toBe("string");
+    });
 });

--- a/src/ApiDocField.ts
+++ b/src/ApiDocField.ts
@@ -7,7 +7,7 @@ export class ApiDocField {
     private readonly allowedValues: Array<string>;
     private readonly _fieldName: string;
     private readonly _qualifiedName: Array<string>;
-    public readonly isArray;
+    public readonly isArray: boolean;
 
     get required() {
         return !this.optional;
@@ -34,8 +34,8 @@ export class ApiDocField {
     }
 
     constructor(field: IApiDocField) {
-        this._type = field.type.replace("[]", "");
-        this.isArray = field.type.endsWith("[]");
+        this._type = field.type ? field.type.replace("[]", "") : "string";
+        this.isArray = field.type ? field.type.endsWith("[]") : false;
         this._fieldName = field.field;
         this._qualifiedName = this._fieldName.split(".");
         this.optional = Boolean(field.optional);

--- a/src/ApiDocInterfaces.ts
+++ b/src/ApiDocInterfaces.ts
@@ -40,7 +40,7 @@ export interface IApiDocHeader {
 
 export interface IApiDocField {
     group?: string;
-    type: string;
+    type?: string;
     field: string;
     optional?: boolean;
     allowedValues?: Array<string>;


### PR DESCRIPTION
- [x]  Я залогал время по этому тикету
- [x]  Я протестил тикет

#### Краткое описание
У полей ошибки дефолтным типом всегда является `string`, который apiDoc не пишет, что не было учтено, до этого момента. Теперь любое поле без типа считается строкой, что в принципе может быть только в полях ошибок.

**Related jira issues:**
> [EWN-12340](https://j.readdle.com/browse/EWN-12340)
