### PR TITLE
EWN-12345 Handle uppercase types in parser

### DIFF
--- a/src/ApiDocEndpointParser.test.ts
+++ b/src/ApiDocEndpointParser.test.ts
@@ -31,7 +31,12 @@ const parentField = {
     field: "user",
 };
 
-const parentArrayField = {
+const parentUppercaseArrayField = {
+    type: "Array",
+    field: "user",
+};
+
+const parentObjectArrayField = {
     type: "object[]",
     field: "user",
 };
@@ -197,7 +202,21 @@ describe("apiDoc Endpoint", () => {
         const endpointWithNestedFields = {
             parameter: {
                 fields: {
-                    Parameter: [parentArrayField, nestedField],
+                    Parameter: [parentObjectArrayField, nestedField],
+                },
+            },
+            ...defaultEndpointMetadata,
+        };
+
+        const schema = parser.parseEndpoint(endpointWithNestedFields).request;
+        expect(schema).toHaveProperty("properties.user.items.properties.name");
+    });
+
+    it("should write nested fields of field with type 'array' to 'items.properties'", () => {
+        const endpointWithNestedFields = {
+            parameter: {
+                fields: {
+                    Parameter: [parentUppercaseArrayField, nestedField],
                 },
             },
             ...defaultEndpointMetadata,

--- a/src/ApiDocEndpointParser.ts
+++ b/src/ApiDocEndpointParser.ts
@@ -63,7 +63,10 @@ export class ApiDocEndpointParser {
     }
 
     private createParentProperties(parentProperties: JsonSchema, currentNamePart: string): JsonSubSchemas {
-        if (parentProperties[currentNamePart] && parentProperties[currentNamePart].type === "array") {
+        if (
+            parentProperties[currentNamePart]
+            && parentProperties[currentNamePart].type.toLowerCase() === "array"
+        ) {
             return this.createArrayProperties(parentProperties, currentNamePart);
         }
 


### PR DESCRIPTION
- [x]  Я залогал время по этому тикету
- [x]  Я протестил тикет

#### Краткое описание
Теперь учитывается то, что тип `array` может быть написан с большой буквы, все очень просто.

**Related jira issues:**
> [EWN-12345](https://j.readdle.com/browse/EWN-12345)
