### PR TITLE
EWN 12503 Default output flag value

### DIFF
--- a/src/cli/InputParser.test.ts
+++ b/src/cli/InputParser.test.ts
@@ -67,6 +67,15 @@ describe("CLI InputParser", () => {
         await expect(inputParser.parse({config: "/invalid-config.js"})).rejects.toThrow();
     });
 
+    it("should replace missing 'output' flag with default value", async () => {
+        existsSpy.mockReturnValue(false);
+        const result = await inputParser.parse({
+            source: "source",
+            name: "name",
+        });
+        expect(result.runParameters.output).toBe("./");
+    });
+
     it("should not throw an error if 'name' is not specified and grouping is set to 'url'", async () => {
         existsSpy.mockReturnValue(false);
         await expect(inputParser.parse({

--- a/src/cli/InputParser.ts
+++ b/src/cli/InputParser.ts
@@ -21,6 +21,8 @@ export class InputParser {
         const flags = cliFlags.config
                       ? await this.readConfigFlags(cliFlags.config)
                       : await this.combineDefaultConfigAndCliFlags(cliFlags);
+
+        flags.output = flags.output || "./";
         this.validateInput(flags);
 
         return {


### PR DESCRIPTION
- [ ]  Я залогал время по этому тикету
- [x]  Я протестил тикет

#### Краткое описание
Дефолтное значение для `output` теперь это текущая папка. Заодно теперь `name` не требуется, если `grouping` стоит `url`.

**Related jira issues:**
> [EWN-12503](https://j.readdle.com/browse/EWN-12503)
