### PR TITLE
Update git hook for branch name checking

### DIFF
--- a/.git-scripts/check-branch-name.js
+++ b/.git-scripts/check-branch-name.js
@@ -2,7 +2,7 @@
 
 const childProcessExec = require('child_process').exec;
 const util = require('util');
-const branchRegex = new RegExp("EWN-\\d+\\/[\\w-]+");
+const branchRegex = new RegExp("(?:impr|fix|feat|ref)\\/[\\w-]+");
 
 const exec = util.promisify(childProcessExec);
 
@@ -28,7 +28,9 @@ async function checkBranchName() {
     }
 
     console.log("Invalid branch name");
-    console.log("Use EWN-######/my-description-message");
+    console.log("Branch name should start with: 'impr', 'fix', 'feat' or 'ref'");
+    console.log("Please check contributing guide for more information");
+    console.log("https://github.com/fluix/web-apidoc2ts/blob/develop/CONTRIBUTING.md");
     process.exit(1);
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,17 @@ Open a new GitHub pull request with the patch. Description should clearly descri
 ### Code conventions?
 
 Currently we are following the extended Airbnb code style and have tslint rules for that. We use UpperCamelCase for files and kebab-case for directories. Also we are covering with tests every piece of functionality that we have. Besides that commit messages should consist of one-line header with a present tense imperative and a longer description of what and probably why something have been changed if needed.
+
+Branch names should start with specific prefix and follow up with some description in kebab-case after slash.
+Prefixes:
+- `feat` - for any new features
+- `fix` - for any fixes
+- `impr` - for small improvements
+- `ref` - for refactoring
+
+If a branch contains several types of this changes then the prefix should reflect the main purpose of the branch/PR.
+
+Examples:
+- `feat/add-new-feature`
+- `fix/fixed-some-bug`
+


### PR DESCRIPTION
#### Short description
Updated git hook due to the fact that this project is now open-source. Old git hook was checking for a Jira task number in branch name. Now it checks for some default prefixes described in contributing guide.

#### How to review
Start of with contributing guide and then check update hook.
