### PR TITLE
Change source argument purpose.

### DIFF
--- a/src/cli/Index.ts
+++ b/src/cli/Index.ts
@@ -23,7 +23,7 @@ class Convert extends Command {
         }),
         source: flags.string({
             char: "s",
-            description: "Path to the api_data.json",
+            description: "Path to the apidoc folder",
             exclusive: ["config"],
         }),
         output: flags.string({

--- a/src/core/ApiDoc2Interface.test.ts
+++ b/src/core/ApiDoc2Interface.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as path from "path";
 import {ApiDoc2Interface, ApiDoc2InterfaceExitCode, ApiDoc2InterfaceGroupingMode} from "./ApiDoc2Interface";
 import {ApiDocToInterfaceConverter} from "./endpoint-converter/ApiDocToInterfaceConverter";
 
@@ -32,7 +33,7 @@ describe("ApiDoc2Interface wrapper", () => {
         interfaceWriterFactoryMock,
     );
     const args = {
-        source: "path/to/the/file",
+        source: "path/to/apidoc",
         output: "path/to/the/output",
         name: "interfaces.ts",
         grouping: ApiDoc2InterfaceGroupingMode.SINGLE,
@@ -49,9 +50,9 @@ describe("ApiDoc2Interface wrapper", () => {
         writeInterfacesMock.mockReset();
     });
 
-    it("should call readFile with given path", async () => {
+    it("should call readFile for api_data.json file in provided apidoc source", async () => {
         await apiDoc2Interface.run(args);
-        expect(readFileSpy).toBeCalledWith(args.source, "utf-8", expect.anything());
+        expect(readFileSpy).toBeCalledWith(path.join(args.source, "api_data.json"), "utf-8", expect.anything());
     });
 
     it("should throw an error when readFile failed", async () => {

--- a/src/core/ApiDoc2Interface.ts
+++ b/src/core/ApiDoc2Interface.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as path from "path";
 import {promisify} from "util";
 import {ApiDocToInterfaceConverter, ConverterResult} from "./endpoint-converter/ApiDocToInterfaceConverter";
 import {ApiDocFieldsParser} from "./endpoint-parser/ApiDocFieldsParser";
@@ -48,7 +49,7 @@ export class ApiDoc2Interface {
 
     async run(args: ApiDoc2InterfaceParameters): Promise<ApiDoc2InterfaceResult> {
         const warnings: Array<string> = [];
-        return readFile(args.source, "utf-8")
+        return readFile(path.join(args.source, "api_data.json"), "utf-8")
             .then((fileData) => {
                 const apiDocEndpoints = JSON.parse(fileData);
                 return this.converter.convert(apiDocEndpoints);


### PR DESCRIPTION
- [x]  I wrote/rewrote tests for the changes
- [x]  I have tested the changes

#### Short description
Implementation of https://github.com/fluix/web-apidoc2ts/issues/70
Changed purpose of source argument
Instead of path to api_data.json user should pass only apidoc folder path

#### How to test it
Call apidoc2ts as usual, but instead of full path to api_data.json you should provide only path to apidata folder

#### Any additional information
This change will break existing configs, so it should be covered in "Breaking changes" section of upcoming release
