### PR TITLE
Clear dist folder before build in prepack script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apidoc2ts",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apidoc2ts",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Typescript interface generator based on ApiDoc",
   "bin": {
     "apidoc2ts": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint -c .eslintrc.js --fix 'src/**/*.ts'",
     "lint:strict": "eslint -c .eslintrc.js 'src/**/*.ts'",
     "postpack": "rm -f oclif.manifest.json",
-    "prepack": "npm run build && oclif-dev manifest"
+    "prepack": "rm -rf dist && npm run build && oclif-dev manifest"
   },
   "jest": {
     "preset": "ts-jest//presets/default",


### PR DESCRIPTION
#### Short description
Removing `dist` folder in order to prevent any problems with publishing and old version to npm.
